### PR TITLE
fix: Routing, DB관련 전반적인 오류 수정, Mypage 정상화

### DIFF
--- a/models/pseudoSession.model.js
+++ b/models/pseudoSession.model.js
@@ -19,9 +19,10 @@ const pseudoSessionSchema = new Schema({
 
 pseudoSessionSchema.pre("save", async function (next) {
   try {
-    const salt = await bcrypt.genSalt(10);
-    const hashedRefreshToken = await bcrypt.hash(this.refreshToken, salt);
-    const hashedAccessToken = await bcrypt.hash(this.accessToken, salt);
+    const salt1 = await bcrypt.genSalt(10);
+    const salt2 = await bcrypt.genSalt(10);
+    const hashedRefreshToken = await bcrypt.hash(this.refreshToken, salt1);
+    const hashedAccessToken = await bcrypt.hash(this.accessToken, salt2);
     this.refreshToken = hashedRefreshToken;
     this.accessToken = hashedAccessToken;
   } catch (error) {
@@ -35,8 +36,8 @@ pseudoSessionSchema.methods.isValidTokens = async function (
 ) {
   try {
     if (
-      bcrypt.compare(refreshToken, this.refreshToken) &&
-      bcrypt.compare(accessToken, this.accessToken)
+      bcrypt.compareSync(refreshToken, this.refreshToken) &&
+      bcrypt.compareSync(accessToken, this.accessToken)
     ) {
       return true;
     } else return false;

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -29,16 +29,6 @@ userSchema.pre("save", async function (next) {
   }
 });
 
-userSchema.pre("updateOne", async function (next) {
-  try {
-    const salt = await bcrypt.genSalt(10);
-    const hashedPassword = await bcrypt.hash(this.password, salt);
-    this.password = hashedPassword;
-  } catch (error) {
-    next(error);
-  }
-});
-
 userSchema.methods.isValidPassword = async function (password) {
   try {
     return await bcrypt.compare(password, this.password);

--- a/public/js/mypage.js
+++ b/public/js/mypage.js
@@ -28,7 +28,7 @@ function updateUserInfo() {
         password: newPw1,
     };
 
-    fetch("http://localhost:3000/mypage/update", {
+    fetch("http://localhost:3000/users/mypage/update", {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
@@ -51,7 +51,7 @@ function updateUserInfo() {
 //비동기 함수로 변경
 //서버로부터 유저 정보 가져오기
 function requestUserInfo(accessToken) {
-    fetch("http://localhost:3000/mypage", {
+    fetch("http://localhost:3000/users/mypage", {
         method: "GET",
         headers: {
             accessToken: accessToke,

--- a/resources/jwt_management.js
+++ b/resources/jwt_management.js
@@ -29,8 +29,11 @@ const token = {
    *Access Token의 유효성을 검증합니다
    */
   verifyAccessToken: (req, res, next) => {
-    if (!req.headers["authorization"])
+    if (!req.headers["authorization"]) {
+      console.log("요청오류발생");
       return next(createError.Unauthorized("잘못된 요청입니다"));
+    }
+
     const authHeader = req.headers["authorization"];
     const bearerToken = authHeader.split(" ");
     const token = bearerToken[1];
@@ -39,9 +42,11 @@ const token = {
       if (error) {
         const message =
           error.name === "JsonWebTokenError" ? "Unauthorized" : error.message;
+        console.log(message);
         return next(createError.Unauthorized(message));
       }
       req.payload = payload;
+      console.log(req.payload);
       next();
     });
   },

--- a/routes/auth.route.js
+++ b/routes/auth.route.js
@@ -1,18 +1,16 @@
-/**
- * 회원가입 홈페이지에서의 Routing을 담당합니다
- */
-
 var express = require("express");
 var router = express.Router();
 
 const ctrl = require("./control/auth.control");
+const accessCtrl = require("./control/access.control");
 const { token } = require("../resources/jwt_management.js");
 
-router.get("/", token.verifyAccessToken, async function (req, res, next) {
-  res.send({
-    success: true,
-  });
-});
+router.get(
+  "/",
+  token.verifyAccessToken,
+  accessCtrl.findOut.isAuthUser,
+  accessCtrl.findOut.whatProblemIs
+);
 
 /**
  * 회원가입 요청을 처리합니다

--- a/routes/control/access.control.js
+++ b/routes/control/access.control.js
@@ -1,0 +1,62 @@
+const createError = require("http-errors");
+const { token } = require("../../resources/jwt_management.js");
+
+const allow = {
+  /**
+   * 인증된 유저만 통과시키는 Router입니다
+   */
+  onlyAuthUser: async function (req, res, next) {
+    try {
+      token.verifyAccessToken(req, res, next);
+    } catch (error) {
+      if (error.status == 401 && error.message == "jwp expired") {
+        res.send({
+          success: false,
+          message:
+            "AccessToken이 만료되었습니다. RefreshToken을 재발급받으십시오",
+        });
+      }
+    }
+  },
+};
+
+const findOut = {
+  /**
+   * 유저의 인증 여부를 확인하기만 하고, 그 결과를 사용자에게 넘기는 Router입니다
+   */
+  isAuthUser: async function (req, res, next) {
+    if (req.payload) {
+      res.send({
+        success: true,
+        message: "유저가 감지되었습니다",
+      });
+    } else {
+      next(createError.InternalServerError());
+    }
+  },
+
+  whatProblemIs: async function (error, req, res, next) {
+    if (error.status == 401 && error.message == "jwp expired") {
+      res.send({
+        success: false,
+        message:
+          "AccessToken이 만료되었습니다. RefreshToken을 재발급받으십시오",
+      });
+    } else if (
+      error.status == 401 &&
+      (error.message == "Unauthorized" || error.message == "잘못된 요청입니다")
+    ) {
+      res.send({
+        success: false,
+        message: "로그인되지 않은 사용자입니다",
+      });
+    } else {
+      next(error);
+    }
+  },
+};
+
+module.exports = {
+  allow,
+  findOut,
+};

--- a/routes/users.route.js
+++ b/routes/users.route.js
@@ -4,11 +4,12 @@ var router = express.Router();
 const { token } = require("../resources/jwt_management");
 
 const ctrl = require("./control/users.control");
+const accessCtrl = require("./control/access.control");
 
 /**
  * /user/... 주소에 대한 모든 접근은 사용자의 access token 검증을 필요로 합니다
  */
-router.use("/", token.verifyAccessToken);
+router.use("/", accessCtrl.allow.onlyAuthUser);
 
 /**
  * 유저 정보 수정 페이지와 함께 유저 정보를 전송합니다


### PR DESCRIPTION
구현된 사항:
1. Access Token을 포함한 GET 요청에 대한 대응 라우팅 경로 구현 (/auth)
 - Access Token의 유효성을 검사하고 response body의 success 필드에 성공여부를 전송
 - 유효성 검사 실패 시(시간 만료, 손상된 토큰 등) 그 원인을 response body의 message 필드에 전송
   -> 토큰 만료 시 refresh token 재발급, 토큰 손상 시 로그인 페이지로 이동 등 클라이언트가 능동적으로 대응 가능
2. Mypage 동작 정상화
3. DB에 Session 저장 시 암호화가 제대로 되지 않던 점을 수정
4. Refresh Token 재발급을 위해 다음과 같은 조건의 요청이 필요하도록 수정
 - 사용자는 보유중인(만료된) Access Token과 이와 함께 생성된 Refresh Token을 전부 보내야 함
 - 사용자의 Refresh Token이 유효할 것
 - 사용자의 Refresh Token에 대응하는 Session이 현재 존재할 것
  -> Access Token - Refresh Token의 쌍이 서버 Session에 남게 되므로, Refresh Token은 일회성임
5. 유저의 로그인 여부를 확인하여 접속을 제한하는 라우팅 미들웨어 추가 (access.control.js)