### PR TITLE
feat: 유저 필터링 매커니즘 추가

### DIFF
--- a/models/users.model.js
+++ b/models/users.model.js
@@ -17,6 +17,14 @@ const userSchema = new Schema({
     type: String,
     required: true,
   },
+  isDev: {
+    type: Boolean,
+    default: false,
+  },
+  isAdmin: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 userSchema.pre("save", async function (next) {

--- a/resources/jwt_management.js
+++ b/resources/jwt_management.js
@@ -10,7 +10,7 @@ const token = {
       const payload = {};
       const secret = process.env.ACCESS_TOKEN_SECRET;
       const options = {
-        expiresIn: "1d",
+        expiresIn: "5m",
         issuer: "netronics.com",
         audience: userID,
       };
@@ -30,8 +30,7 @@ const token = {
    */
   verifyAccessToken: (req, res, next) => {
     if (!req.headers["authorization"]) {
-      console.log("요청오류발생");
-      return next(createError.Unauthorized("잘못된 요청입니다"));
+      return next(createError.Unauthorized("noAccessTokenError"));
     }
 
     const authHeader = req.headers["authorization"];
@@ -42,11 +41,14 @@ const token = {
       if (error) {
         const message =
           error.name === "JsonWebTokenError" ? "Unauthorized" : error.message;
-        console.log(message);
-        return next(createError.Unauthorized(message));
+        if (error.message === "jwt expired") {
+          return next(createError.Unauthorized("expiredTokenError"));
+        } else {
+          return next(createError.Unauthorized(message));
+        }
       }
       req.payload = payload;
-      console.log(req.payload);
+      console.log(payload);
       next();
     });
   },

--- a/routes/auth.route.js
+++ b/routes/auth.route.js
@@ -4,12 +4,27 @@ var router = express.Router();
 const ctrl = require("./control/auth.control");
 const accessCtrl = require("./control/access.control");
 const { token } = require("../resources/jwt_management.js");
+const user = require("../models/users.model.js");
 
 router.get(
-  "/",
+  "/getUserInfo",
   token.verifyAccessToken,
-  accessCtrl.findOut.isAuthUser,
-  accessCtrl.findOut.whatProblemIs
+  async function (req, res, next) {
+    if (req.payload) {
+      const payload = req.payload;
+      const foundUser = await user.findOne({ userID: payload.aud });
+
+      foundUser.password = null;
+
+      res.send({
+        success: true,
+        foundUser,
+      });
+    } else {
+      return next();
+    }
+  },
+  ctrl.process.getUserInfo
 );
 
 /**

--- a/routes/control/auth.control.js
+++ b/routes/control/auth.control.js
@@ -217,6 +217,33 @@ const process = {
       next(error);
     }
   },
+
+  /**
+   * 회원정보 불러오기 요청의 실행을 담당합니다
+   */
+  getUserInfo: async function (error, req, res, next) {
+    if (error.status === 401) {
+      switch (error.message) {
+        case "noAccessTokenError": {
+          res.send({
+            success: false,
+            message: "로그아웃된 유저입니다",
+          });
+          break;
+        }
+        case "expiredTokenError": {
+          res.send({
+            success: false,
+            message: "Access Token 만료. 재발급 수행 후 재시도하십시오",
+          });
+          break;
+        }
+        default: {
+          console.log("대응 범위 이외의 오류");
+        }
+      }
+    }
+  },
 };
 
 module.exports = {

--- a/routes/control/users.control.js
+++ b/routes/control/users.control.js
@@ -1,13 +1,13 @@
 const user = require("../../models/users.model.js");
 
 const rend = {
+  /**
+   * 마이페이지와 함께 유저의 정보를 전송합니다
+   */
   mypage: async function (req, res, next) {
-    const userID = req.payload.aud;
-    const foundUser = user.findOne({ userID: userID });
-
     res.render("mypage", {
-      userID: userID,
-      name: foundUser.name,
+      success: true,
+      userInfo: req.foundUser,
     });
   },
 };

--- a/routes/users.route.js
+++ b/routes/users.route.js
@@ -10,10 +10,14 @@ const accessCtrl = require("./control/access.control");
  * /user/... 주소에 대한 모든 접근은 사용자의 access token 검증을 필요로 합니다
  */
 router.use("/", accessCtrl.allow.onlyAuthUser);
+router.use("/", token.verifyAccessToken);
+router.use("/", accessCtrl.filterUser);
 
 /**
  * 유저 정보 수정 페이지와 함께 유저 정보를 전송합니다
  */
 router.get("/mypage", ctrl.rend.mypage);
+
+router.use("/", accessCtrl.handleError);
 
 module.exports = router;


### PR DESCRIPTION
수정된 사항:
1. 유저 정보를 받아오는 절차를 대폭 수정하였습니다.
 - 유저의 정보를 받아오기 위해 기존의 .../auth/ 경로가 아닌, .../auth/getUserInfo를 이용합니다. .../auth/ 경로를 계속해서 사용하면 향후 라우팅 경로를 확장하는 데 있어 어려움이 있을 것으로 보아 이와 같이 변경하였습니다.
2. 마이페이지는 다음과 같은 형태로 render됩니다.
> res.render("mypage", {
>     success: true,
>     userInfo: req.foundUser,
>   });
 따라서 서버에서 전송한 유저 정보를 mypage 내에서 사용하기 위해서는 다음과 같이 접근하십시오 ->
 ex. 아이디를 얻어오고 싶다 => user_id = userInfo.userID;
3. 향후 서버 확장성을 고려하여, 인증되지 않은 유저를 차단하는 라우팅 미들웨어들을 제작하였습니다
 - .../users/의 라우팅 경로를 갖는 모든 접근은 인증되지 않은 유저를 차단하도록 하였으며, 이는 users/mypage에도 적용됩니다.
 - 사용자를 운영자(Admin)와 개발자(Dev)로 세분화하여, 특정 자격을 갖는 유저만을 통과시키는 미들웨어들 또한 제작하였습니다. 다만 현 시점에서 사용되지는 않습니다.

